### PR TITLE
fix(deps): update broker peer @angular/common (CVE-2025-66035)

### DIFF
--- a/angular-libs/projects/broker/package-lock.json
+++ b/angular-libs/projects/broker/package-lock.json
@@ -1,117 +1,78 @@
 {
   "name": "@czprz/broker",
   "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@czprz/broker",
       "version": "1.0.0",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.6.2"
       },
       "peerDependencies": {
-        "@angular/common": "^14.2.0",
-        "@angular/core": "^14.2.0"
+        "@angular/common": "^21.2.6",
+        "@angular/core": "^21.2.6"
       }
     },
     "node_modules/@angular/common": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.5.tgz",
-      "integrity": "sha512-v2fIK6imfMkUvYNjZQO+drE39QO3eSS95Yy7UN+6inb47DkAfzx6hipA9zKrMENjsS3kDv1d7cgDHE7WuOCzIw==",
+      "version": "21.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.7.tgz",
+      "integrity": "sha512-YFdnU5z8JloJjLYa52OyCOULQhqEE/ym7vKfABySWDsiVXZr9FNmKMeZi/lUcg7ZO22UbBihqW9a9D6VSHOo+g==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "engines": {
-        "node": "^14.15.0 || >=16.10.0"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "14.2.5",
+        "@angular/core": "21.2.7",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/core": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.5.tgz",
-      "integrity": "sha512-Ok78Abq0puMGlolvNVzKFvsX7ePDkyxpZzztDzXDdRA4x4o6bAuuDG9Y7Wab2+wsdY6NktO+dFQjq1UBWClgSg==",
+      "version": "21.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.7.tgz",
+      "integrity": "sha512-4bnskeRNNOZMn3buVw47Zz9Py4B8AZgYHe5xBEMOY5/yrldb7OFje5gWCWls23P18FKwhl+Xx1hgnOEPSs29gw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "engines": {
-        "node": "^14.15.0 || >=16.10.0"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
+        "@angular/compiler": "21.2.7",
         "rxjs": "^6.5.3 || ^7.4.0",
-        "zone.js": "~0.11.4"
+        "zone.js": "~0.15.0 || ~0.16.0"
+      },
+      "peerDependenciesMeta": {
+        "@angular/compiler": {
+          "optional": true
+        },
+        "zone.js": {
+          "optional": true
+        }
       }
     },
     "node_modules/rxjs": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "node_modules/zone.js": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.8.tgz",
-      "integrity": "sha512-82bctBg2hKcEJ21humWIkXRlLBBmrc3nN7DFh5LGGhcyycO2S7FN8NmdvlcKaGFDNVL4/9kFLmwmInTavdJERA==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.3.0"
-      }
-    }
-  },
-  "dependencies": {
-    "@angular/common": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.2.5.tgz",
-      "integrity": "sha512-v2fIK6imfMkUvYNjZQO+drE39QO3eSS95Yy7UN+6inb47DkAfzx6hipA9zKrMENjsS3kDv1d7cgDHE7WuOCzIw==",
-      "peer": true,
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@angular/core": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.5.tgz",
-      "integrity": "sha512-Ok78Abq0puMGlolvNVzKFvsX7ePDkyxpZzztDzXDdRA4x4o6bAuuDG9Y7Wab2+wsdY6NktO+dFQjq1UBWClgSg==",
-      "peer": true,
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "rxjs": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
-      "peer": true,
-      "requires": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "zone.js": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.8.tgz",
-      "integrity": "sha512-82bctBg2hKcEJ21humWIkXRlLBBmrc3nN7DFh5LGGhcyycO2S7FN8NmdvlcKaGFDNVL4/9kFLmwmInTavdJERA==",
-      "peer": true,
-      "requires": {
-        "tslib": "^2.3.0"
-      }
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     }
   }
 }

--- a/angular-libs/projects/broker/package.json
+++ b/angular-libs/projects/broker/package.json
@@ -2,8 +2,8 @@
   "name": "@czprz/broker",
   "version": "1.0.0",
   "peerDependencies": {
-    "@angular/common": "^16.2.9",
-    "@angular/core": "^16.2.9"
+    "@angular/common": "^21.2.6",
+    "@angular/core": "^21.2.6"
   },
   "dependencies": {
     "tslib": "^2.6.2"


### PR DESCRIPTION
Resolves Dependabot alert #431 (CVE-2025-66035).

- Updated angular-libs/projects/broker peerDependencies to @angular/common/@angular/core ^21.2.6
- Regenerated broker package-lock.json (now resolves @angular/common 21.2.7)

Alert: https://github.com/dever-labs/angular-micro-frontend/security/dependabot/431