### PR TITLE
chore(deps): batch dependency updates 2026-04-26

### DIFF
--- a/angular-libs/package-lock.json
+++ b/angular-libs/package-lock.json
@@ -9442,9 +9442,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -21553,9 +21553,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true
     },
     "forwarded": {

--- a/angular-libs/package-lock.json
+++ b/angular-libs/package-lock.json
@@ -9739,9 +9739,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "dev": true,
       "engines": {
         "node": ">=16.9.0"
@@ -21734,9 +21734,9 @@
       }
     },
     "hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "dev": true
     },
     "hosted-git-info": {

--- a/angular-menu/package-lock.json
+++ b/angular-menu/package-lock.json
@@ -9522,16 +9522,15 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -21089,9 +21088,9 @@
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
     },
     "follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
     },
     "form-data": {
       "version": "4.0.5",

--- a/angular-menu/package-lock.json
+++ b/angular-menu/package-lock.json
@@ -3994,12 +3994,12 @@
       }
     },
     "node_modules/@module-federation/bridge-react-webpack-plugin": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.3.1.tgz",
-      "integrity": "sha512-rixIHit2xeusr052t/IOfgQa9OyKc21GiJC8uE/5szmgJlJOHmiXa7QrudKb4KVDCcbd5Ad2b4+XrSYxxRUzJA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.3.3.tgz",
+      "integrity": "sha512-W2jQ3Wuqree9Dq3UAx8jGbYtvHuuYgzrd2j9FP8Bt6NaynaNU1yYG86MBnAhZJPTltex0CguudR1dgFpYdvLUg==",
       "peer": true,
       "dependencies": {
-        "@module-federation/sdk": "2.3.1",
+        "@module-federation/sdk": "2.3.3",
         "@types/semver": "7.5.8",
         "semver": "7.6.3"
       }
@@ -4017,14 +4017,13 @@
       }
     },
     "node_modules/@module-federation/cli": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.3.1.tgz",
-      "integrity": "sha512-9oUqFuXaZgUc1ptBPKLIUmKrzu0kog1kE05BLMEUm55JkiDtODpuzQhT/QL8h0qHBeZ70Rn12ARQQBmoZT61Aw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.3.3.tgz",
+      "integrity": "sha512-g3f3aEruv07zK4VcUlAllswrp2ncA/jF0P0yoEWNRa9K7N+xNCfqcdzw2aVWOJ30qNMurhLWuyzYqfDIx0LpfQ==",
       "peer": true,
       "dependencies": {
-        "@module-federation/dts-plugin": "2.3.1",
-        "@module-federation/sdk": "2.3.1",
-        "chalk": "3.0.0",
+        "@module-federation/dts-plugin": "2.3.3",
+        "@module-federation/sdk": "2.3.3",
         "commander": "11.1.0",
         "jiti": "2.4.2"
       },
@@ -4033,34 +4032,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@module-federation/cli/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@module-federation/cli/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@module-federation/cli/node_modules/commander": {
@@ -4081,27 +4052,14 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/@module-federation/cli/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@module-federation/data-prefetch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-2.3.1.tgz",
-      "integrity": "sha512-p/G5Nlu7buiE7TdrznHanxFS1Zik8nmzNUDLmgwfdHRIaH7Rj4+gLIgLg5Zrjtkdvae/L2UJpcC8QopJMQjv4A==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-2.3.3.tgz",
+      "integrity": "sha512-ZM1QtyjbWYnhUizHFhwYjHGXlkZek3vzTpL35d5FkAhVrOU0u0Qv6zpZjdcCm0FJznqVsUQx1w0vagUyGWQf0g==",
       "peer": true,
       "dependencies": {
-        "@module-federation/runtime": "2.3.1",
-        "@module-federation/sdk": "2.3.1",
-        "fs-extra": "9.1.0"
+        "@module-federation/runtime": "2.3.3",
+        "@module-federation/sdk": "2.3.3"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -4117,21 +4075,20 @@
       }
     },
     "node_modules/@module-federation/dts-plugin": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.3.1.tgz",
-      "integrity": "sha512-6BJvu+dLDtW/ngpyuOLgpKOgtOnMUTZY51JUyargVckerKRbe7Ul+414YaHj32mu2FpsiHVMl4ig1XnxgnRg2Q==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.3.3.tgz",
+      "integrity": "sha512-VNtURt+hvieNKCBleAqHKffLAU4clKmuuqLQIbvDkFbGe4bo7hUaq5DruTnJBWWDOizZx0OQrdQYPijCnBK6UQ==",
       "peer": true,
       "dependencies": {
-        "@module-federation/error-codes": "2.3.1",
-        "@module-federation/managers": "2.3.1",
-        "@module-federation/sdk": "2.3.1",
-        "@module-federation/third-party-dts-extractor": "2.3.1",
-        "adm-zip": "^0.5.10",
-        "ansi-colors": "^4.1.3",
-        "axios": "1.13.5",
-        "fs-extra": "9.1.0",
+        "@module-federation/error-codes": "2.3.3",
+        "@module-federation/managers": "2.3.3",
+        "@module-federation/sdk": "2.3.3",
+        "@module-federation/third-party-dts-extractor": "2.3.3",
+        "adm-zip": "0.5.10",
+        "ansi-colors": "4.1.3",
         "isomorphic-ws": "5.0.0",
         "node-schedule": "2.1.1",
+        "undici": "7.24.7",
         "ws": "8.18.0"
       },
       "peerDependencies": {
@@ -4142,6 +4099,15 @@
         "vue-tsc": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@module-federation/dts-plugin/node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@module-federation/dts-plugin/node_modules/ws": {
@@ -4166,24 +4132,24 @@
       }
     },
     "node_modules/@module-federation/enhanced": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.3.1.tgz",
-      "integrity": "sha512-zvzymtzsYVlSPt/HKjm42OGiDxUDPLce7mr6VZw4d6//AFFK3kKUEpUqwlf/bIlbg7FbwJC/7hVCmUhlF+dxgw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.3.3.tgz",
+      "integrity": "sha512-BJSs56lqO9NI9aC+hVhg2CU/UwG1TphVl1b7WBx6Jv6DYUyVQbgXeQpgqYVsxYVRKYOl7eDZmjXl2eA/n1IP/Q==",
       "peer": true,
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "2.3.1",
-        "@module-federation/cli": "2.3.1",
-        "@module-federation/data-prefetch": "2.3.1",
-        "@module-federation/dts-plugin": "2.3.1",
-        "@module-federation/error-codes": "2.3.1",
-        "@module-federation/inject-external-runtime-core-plugin": "2.3.1",
-        "@module-federation/managers": "2.3.1",
-        "@module-federation/manifest": "2.3.1",
-        "@module-federation/rspack": "2.3.1",
-        "@module-federation/runtime-tools": "2.3.1",
-        "@module-federation/sdk": "2.3.1",
-        "@module-federation/webpack-bundler-runtime": "2.3.1",
-        "schema-utils": "^4.3.0",
+        "@module-federation/bridge-react-webpack-plugin": "2.3.3",
+        "@module-federation/cli": "2.3.3",
+        "@module-federation/data-prefetch": "2.3.3",
+        "@module-federation/dts-plugin": "2.3.3",
+        "@module-federation/error-codes": "2.3.3",
+        "@module-federation/inject-external-runtime-core-plugin": "2.3.3",
+        "@module-federation/managers": "2.3.3",
+        "@module-federation/manifest": "2.3.3",
+        "@module-federation/rspack": "2.3.3",
+        "@module-federation/runtime-tools": "2.3.3",
+        "@module-federation/sdk": "2.3.3",
+        "@module-federation/webpack-bundler-runtime": "2.3.3",
+        "schema-utils": "4.3.0",
         "tapable": "2.3.0",
         "upath": "2.0.1"
       },
@@ -4207,6 +4173,25 @@
         }
       }
     },
+    "node_modules/@module-federation/enhanced/node_modules/schema-utils": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/@module-federation/enhanced/node_modules/tapable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
@@ -4221,97 +4206,55 @@
       }
     },
     "node_modules/@module-federation/error-codes": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.3.1.tgz",
-      "integrity": "sha512-s3IjT2OYrSBNNmxdTmmrWBpsFfeNszdL6BSqjXLHb1CgXWUYLNXpb05IopnzMhRLcur6MTGuKR0ZSjJbmvQBbg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.3.3.tgz",
+      "integrity": "sha512-UVtKBoKnRDcHgByIDvPRZSxQqjqbNH7NvJm1KHLoce33+EDiIdZYs0HvvUQv43RgESpB9s7HjrqFlq3bEcAgfQ==",
       "peer": true
     },
     "node_modules/@module-federation/inject-external-runtime-core-plugin": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.3.1.tgz",
-      "integrity": "sha512-Q/zd3dImx4vyXLQ/UEQ0udL95yPlfbSyKcoW86tIralxA5NgnR3rEp3ccGt9MHSBbCywFrbzX5OwfKW/Jgfexw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.3.3.tgz",
+      "integrity": "sha512-ImSft6hOkMdnpZX8O+RydwkYENxhAwT92n1OAT3Xf01DXMrEpSO0PqBlPGgontxuiaV9dM2/xWSLGuIWaOtupA==",
       "peer": true,
       "peerDependencies": {
-        "@module-federation/runtime-tools": "2.3.1"
+        "@module-federation/runtime-tools": "2.3.3"
       }
     },
     "node_modules/@module-federation/managers": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.3.1.tgz",
-      "integrity": "sha512-kK/4FkoaIxbJbN+R6+cq+igv095hPox8oheZOKkrYA9P6Xv5FiHza+gHlCntiWTMrU8bzqJHH4VYm6gq1RB+dQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.3.3.tgz",
+      "integrity": "sha512-sYL0t2guakJ+nDSQANH54uz5q1YxaNCn5C3lr+7BoRD49dX7Z6k7094yqOPEy8trzqdIoQVFpgewVA6IC/FeyQ==",
       "peer": true,
       "dependencies": {
-        "@module-federation/sdk": "2.3.1",
-        "find-pkg": "2.0.0",
-        "fs-extra": "9.1.0"
-      }
-    },
-    "node_modules/@module-federation/manifest": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.3.1.tgz",
-      "integrity": "sha512-BXckns3ux6Z9XiB2Bpirj/Q3FcQnxiyKt0rx0HmF0/7V6Zy2mwR/011eoeRGHN9N2HZcIxgQcWgMtxl5FAqxyg==",
-      "peer": true,
-      "dependencies": {
-        "@module-federation/dts-plugin": "2.3.1",
-        "@module-federation/managers": "2.3.1",
-        "@module-federation/sdk": "2.3.1",
-        "chalk": "3.0.0",
+        "@module-federation/sdk": "2.3.3",
         "find-pkg": "2.0.0"
       }
     },
-    "node_modules/@module-federation/manifest/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/@module-federation/manifest": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.3.3.tgz",
+      "integrity": "sha512-mAEXuo5sGt8FUDzftU8f0ci0PbsZIDcLRYX9AkXwbXg0JRyVEvWyiBrEKF+zZuy7YM7eRdyp6JjLJPDzufhj5w==",
       "peer": true,
       "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@module-federation/manifest/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@module-federation/manifest/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "@module-federation/dts-plugin": "2.3.3",
+        "@module-federation/managers": "2.3.3",
+        "@module-federation/sdk": "2.3.3",
+        "find-pkg": "2.0.0"
       }
     },
     "node_modules/@module-federation/rspack": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.3.1.tgz",
-      "integrity": "sha512-pZmLSDkD7nDsCc377Q8sB1Yu2iMYFj72VS/Fb8B7uTmhYwU1wqDK9zPwaxauim5Y4TqQBdy/hPzNES3f4lG33Q==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.3.3.tgz",
+      "integrity": "sha512-4s3G+wXZ6J3rKe0EeZnGLQUM7y+qpiI5NM3U6ylZuxD8q7mAwQVHThbH6ruDYUNDVEOc6N0j/+/LdfGRw+e5xw==",
       "peer": true,
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "2.3.1",
-        "@module-federation/dts-plugin": "2.3.1",
-        "@module-federation/inject-external-runtime-core-plugin": "2.3.1",
-        "@module-federation/managers": "2.3.1",
-        "@module-federation/manifest": "2.3.1",
-        "@module-federation/runtime-tools": "2.3.1",
-        "@module-federation/sdk": "2.3.1"
+        "@module-federation/bridge-react-webpack-plugin": "2.3.3",
+        "@module-federation/dts-plugin": "2.3.3",
+        "@module-federation/inject-external-runtime-core-plugin": "2.3.3",
+        "@module-federation/managers": "2.3.3",
+        "@module-federation/manifest": "2.3.3",
+        "@module-federation/runtime-tools": "2.3.3",
+        "@module-federation/sdk": "2.3.3"
       },
       "peerDependencies": {
         "@rspack/core": "^0.7.0 || ^1.0.0 || ^2.0.0-0",
@@ -4328,40 +4271,40 @@
       }
     },
     "node_modules/@module-federation/runtime": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.3.1.tgz",
-      "integrity": "sha512-NiKelHKzOf1Vz8oqcxC/XRUAW224O6lKj9xD0cfp5Bp343iu6s58RlLvX1ypF+UpCl3jA4JM8npGax/3jjyifw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.3.3.tgz",
+      "integrity": "sha512-JYJ3qv9V85DtBtT/ppDuJNwBTUrYqqZDYcyiTzwY5+44dC5QPvgJ//F+BOhAhZ02WkZV0b4jsKTyLOC3vXKGqQ==",
       "peer": true,
       "dependencies": {
-        "@module-federation/error-codes": "2.3.1",
-        "@module-federation/runtime-core": "2.3.1",
-        "@module-federation/sdk": "2.3.1"
+        "@module-federation/error-codes": "2.3.3",
+        "@module-federation/runtime-core": "2.3.3",
+        "@module-federation/sdk": "2.3.3"
       }
     },
     "node_modules/@module-federation/runtime-core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.3.1.tgz",
-      "integrity": "sha512-E0WgaCn32AWzD0n6SCH7VQ+kxk46XyX432PQWARgyQzCX/wyLkaT+We3A18RVNUevRT85YHLrrVIhMKJJVHgjA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.3.3.tgz",
+      "integrity": "sha512-B07LDH9KxhBO3GbULGW64mQFVQBtrEd3PoaCBm7XR1IbU8rMQUJQjDNVZgXYcyhRPBVP+3KWZuiaKFRiNb6PQw==",
       "peer": true,
       "dependencies": {
-        "@module-federation/error-codes": "2.3.1",
-        "@module-federation/sdk": "2.3.1"
+        "@module-federation/error-codes": "2.3.3",
+        "@module-federation/sdk": "2.3.3"
       }
     },
     "node_modules/@module-federation/runtime-tools": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.3.1.tgz",
-      "integrity": "sha512-JrTKnNxIglnwrycPHUz9vARHLWqdecgFJxhmu8991z5CjktHc5JIelCbQS5Ur2lABjuwBdlyw8pH2xI3EJpbOg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.3.3.tgz",
+      "integrity": "sha512-XODzyLbBYcy4wnYBXKIBqaHPVfBx1HshGdjZmSctDDnx9/VYgdx9DShb6UI+WuQBKJgPzTcx4xbvbCM4SdMilQ==",
       "peer": true,
       "dependencies": {
-        "@module-federation/runtime": "2.3.1",
-        "@module-federation/webpack-bundler-runtime": "2.3.1"
+        "@module-federation/runtime": "2.3.3",
+        "@module-federation/webpack-bundler-runtime": "2.3.3"
       }
     },
     "node_modules/@module-federation/sdk": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.1.tgz",
-      "integrity": "sha512-lgWxFZyLRKDXWRGlV6ROjFJ6MRaJTxs0bBnS6hS9ONfr/0TkeW4JzDbsfzrB8g4p6IgSKB+wQ9XfibJCGBI5OQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.3.tgz",
+      "integrity": "sha512-mwCS+LQdqiSc6fM5iz/S60ibaFNSH6kNqlZkCRIuS4yjdZ+jgnihz+6xp1QzppvfFgKLhEHBiXOmcYOdk3Ckew==",
       "peer": true,
       "peerDependencies": {
         "node-fetch": "^3.3.2"
@@ -4373,13 +4316,12 @@
       }
     },
     "node_modules/@module-federation/third-party-dts-extractor": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.3.1.tgz",
-      "integrity": "sha512-YpTLzM7H9damh31JX7eFBiCCR1mbibzS4i4JEa4fZ5ICT4hfNIuaAx1OeICGDOzSdl35TYegegCjk91oX6xCJQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.3.3.tgz",
+      "integrity": "sha512-rR94TjC1QVQLQPTazI0waLc76hI8dnv6aHTl+PUEIY9s5hXp8TA85XS0QJQqIf2KTjlPgZbWAwyFjOAJluTjaw==",
       "peer": true,
       "dependencies": {
         "find-pkg": "2.0.0",
-        "fs-extra": "9.1.0",
         "resolve": "1.22.8"
       }
     },
@@ -4401,14 +4343,14 @@
       }
     },
     "node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.3.1.tgz",
-      "integrity": "sha512-fnsMncVdBYv7a1gN5ElNK1uA9dmGUgaNqcoNiv9xRtpxFYswchl1kbgxPTliCb8U7quihdWZos7P2lvpYeVRwg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.3.3.tgz",
+      "integrity": "sha512-W+P6ZF9J3gwnQuoF07YV0OiR1D6sI/uErUu4+c3QXxka3orANUHujkddNSsDxL1obAGoJa7Da99crZKf7u2j/w==",
       "peer": true,
       "dependencies": {
-        "@module-federation/error-codes": "2.3.1",
-        "@module-federation/runtime": "2.3.1",
-        "@module-federation/sdk": "2.3.1"
+        "@module-federation/error-codes": "2.3.3",
+        "@module-federation/runtime": "2.3.3",
+        "@module-federation/sdk": "2.3.3"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -7459,12 +7401,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
       "peer": true,
       "engines": {
-        "node": ">=12.0"
+        "node": ">=6.0"
       }
     },
     "node_modules/agent-base": {
@@ -7657,21 +7599,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "peer": true
-    },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "peer": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
@@ -7706,17 +7633,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
-      "peer": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-loader": {
@@ -8276,18 +8192,6 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "peer": true,
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -8699,15 +8603,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -8979,21 +8874,6 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "peer": true,
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9541,22 +9421,6 @@
         }
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "peer": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -9599,21 +9463,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "peer": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/fs-minipass": {
@@ -9857,21 +9706,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "peer": true,
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -10613,18 +10447,6 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
-    },
-    "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "peer": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
     },
     "node_modules/jsonparse": {
       "version": "1.3.1",
@@ -12708,12 +12530,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "peer": true
-    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -14401,15 +14217,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/unpipe": {
@@ -17724,12 +17531,12 @@
       }
     },
     "@module-federation/bridge-react-webpack-plugin": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.3.1.tgz",
-      "integrity": "sha512-rixIHit2xeusr052t/IOfgQa9OyKc21GiJC8uE/5szmgJlJOHmiXa7QrudKb4KVDCcbd5Ad2b4+XrSYxxRUzJA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.3.3.tgz",
+      "integrity": "sha512-W2jQ3Wuqree9Dq3UAx8jGbYtvHuuYgzrd2j9FP8Bt6NaynaNU1yYG86MBnAhZJPTltex0CguudR1dgFpYdvLUg==",
       "peer": true,
       "requires": {
-        "@module-federation/sdk": "2.3.1",
+        "@module-federation/sdk": "2.3.3",
         "@types/semver": "7.5.8",
         "semver": "7.6.3"
       },
@@ -17743,37 +17550,17 @@
       }
     },
     "@module-federation/cli": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.3.1.tgz",
-      "integrity": "sha512-9oUqFuXaZgUc1ptBPKLIUmKrzu0kog1kE05BLMEUm55JkiDtODpuzQhT/QL8h0qHBeZ70Rn12ARQQBmoZT61Aw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.3.3.tgz",
+      "integrity": "sha512-g3f3aEruv07zK4VcUlAllswrp2ncA/jF0P0yoEWNRa9K7N+xNCfqcdzw2aVWOJ30qNMurhLWuyzYqfDIx0LpfQ==",
       "peer": true,
       "requires": {
-        "@module-federation/dts-plugin": "2.3.1",
-        "@module-federation/sdk": "2.3.1",
-        "chalk": "3.0.0",
+        "@module-federation/dts-plugin": "2.3.3",
+        "@module-federation/sdk": "2.3.3",
         "commander": "11.1.0",
         "jiti": "2.4.2"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "peer": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "commander": {
           "version": "11.1.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
@@ -17785,48 +17572,43 @@
           "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
           "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
           "peer": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "peer": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },
     "@module-federation/data-prefetch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-2.3.1.tgz",
-      "integrity": "sha512-p/G5Nlu7buiE7TdrznHanxFS1Zik8nmzNUDLmgwfdHRIaH7Rj4+gLIgLg5Zrjtkdvae/L2UJpcC8QopJMQjv4A==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-2.3.3.tgz",
+      "integrity": "sha512-ZM1QtyjbWYnhUizHFhwYjHGXlkZek3vzTpL35d5FkAhVrOU0u0Qv6zpZjdcCm0FJznqVsUQx1w0vagUyGWQf0g==",
       "peer": true,
       "requires": {
-        "@module-federation/runtime": "2.3.1",
-        "@module-federation/sdk": "2.3.1",
-        "fs-extra": "9.1.0"
+        "@module-federation/runtime": "2.3.3",
+        "@module-federation/sdk": "2.3.3"
       }
     },
     "@module-federation/dts-plugin": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.3.1.tgz",
-      "integrity": "sha512-6BJvu+dLDtW/ngpyuOLgpKOgtOnMUTZY51JUyargVckerKRbe7Ul+414YaHj32mu2FpsiHVMl4ig1XnxgnRg2Q==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.3.3.tgz",
+      "integrity": "sha512-VNtURt+hvieNKCBleAqHKffLAU4clKmuuqLQIbvDkFbGe4bo7hUaq5DruTnJBWWDOizZx0OQrdQYPijCnBK6UQ==",
       "peer": true,
       "requires": {
-        "@module-federation/error-codes": "2.3.1",
-        "@module-federation/managers": "2.3.1",
-        "@module-federation/sdk": "2.3.1",
-        "@module-federation/third-party-dts-extractor": "2.3.1",
-        "adm-zip": "^0.5.10",
-        "ansi-colors": "^4.1.3",
-        "axios": "1.13.5",
-        "fs-extra": "9.1.0",
+        "@module-federation/error-codes": "2.3.3",
+        "@module-federation/managers": "2.3.3",
+        "@module-federation/sdk": "2.3.3",
+        "@module-federation/third-party-dts-extractor": "2.3.3",
+        "adm-zip": "0.5.10",
+        "ansi-colors": "4.1.3",
         "isomorphic-ws": "5.0.0",
         "node-schedule": "2.1.1",
+        "undici": "7.24.7",
         "ws": "8.18.0"
       },
       "dependencies": {
+        "undici": {
+          "version": "7.24.7",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+          "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+          "peer": true
+        },
         "ws": {
           "version": "8.18.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
@@ -17837,28 +17619,40 @@
       }
     },
     "@module-federation/enhanced": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.3.1.tgz",
-      "integrity": "sha512-zvzymtzsYVlSPt/HKjm42OGiDxUDPLce7mr6VZw4d6//AFFK3kKUEpUqwlf/bIlbg7FbwJC/7hVCmUhlF+dxgw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.3.3.tgz",
+      "integrity": "sha512-BJSs56lqO9NI9aC+hVhg2CU/UwG1TphVl1b7WBx6Jv6DYUyVQbgXeQpgqYVsxYVRKYOl7eDZmjXl2eA/n1IP/Q==",
       "peer": true,
       "requires": {
-        "@module-federation/bridge-react-webpack-plugin": "2.3.1",
-        "@module-federation/cli": "2.3.1",
-        "@module-federation/data-prefetch": "2.3.1",
-        "@module-federation/dts-plugin": "2.3.1",
-        "@module-federation/error-codes": "2.3.1",
-        "@module-federation/inject-external-runtime-core-plugin": "2.3.1",
-        "@module-federation/managers": "2.3.1",
-        "@module-federation/manifest": "2.3.1",
-        "@module-federation/rspack": "2.3.1",
-        "@module-federation/runtime-tools": "2.3.1",
-        "@module-federation/sdk": "2.3.1",
-        "@module-federation/webpack-bundler-runtime": "2.3.1",
-        "schema-utils": "^4.3.0",
+        "@module-federation/bridge-react-webpack-plugin": "2.3.3",
+        "@module-federation/cli": "2.3.3",
+        "@module-federation/data-prefetch": "2.3.3",
+        "@module-federation/dts-plugin": "2.3.3",
+        "@module-federation/error-codes": "2.3.3",
+        "@module-federation/inject-external-runtime-core-plugin": "2.3.3",
+        "@module-federation/managers": "2.3.3",
+        "@module-federation/manifest": "2.3.3",
+        "@module-federation/rspack": "2.3.3",
+        "@module-federation/runtime-tools": "2.3.3",
+        "@module-federation/sdk": "2.3.3",
+        "@module-federation/webpack-bundler-runtime": "2.3.3",
+        "schema-utils": "4.3.0",
         "tapable": "2.3.0",
         "upath": "2.0.1"
       },
       "dependencies": {
+        "schema-utils": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+          "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+          "peer": true,
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "ajv": "^8.9.0",
+            "ajv-formats": "^2.1.1",
+            "ajv-keywords": "^5.1.0"
+          }
+        },
         "tapable": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
@@ -17868,133 +17662,100 @@
       }
     },
     "@module-federation/error-codes": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.3.1.tgz",
-      "integrity": "sha512-s3IjT2OYrSBNNmxdTmmrWBpsFfeNszdL6BSqjXLHb1CgXWUYLNXpb05IopnzMhRLcur6MTGuKR0ZSjJbmvQBbg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.3.3.tgz",
+      "integrity": "sha512-UVtKBoKnRDcHgByIDvPRZSxQqjqbNH7NvJm1KHLoce33+EDiIdZYs0HvvUQv43RgESpB9s7HjrqFlq3bEcAgfQ==",
       "peer": true
     },
     "@module-federation/inject-external-runtime-core-plugin": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.3.1.tgz",
-      "integrity": "sha512-Q/zd3dImx4vyXLQ/UEQ0udL95yPlfbSyKcoW86tIralxA5NgnR3rEp3ccGt9MHSBbCywFrbzX5OwfKW/Jgfexw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.3.3.tgz",
+      "integrity": "sha512-ImSft6hOkMdnpZX8O+RydwkYENxhAwT92n1OAT3Xf01DXMrEpSO0PqBlPGgontxuiaV9dM2/xWSLGuIWaOtupA==",
       "peer": true,
       "requires": {}
     },
     "@module-federation/managers": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.3.1.tgz",
-      "integrity": "sha512-kK/4FkoaIxbJbN+R6+cq+igv095hPox8oheZOKkrYA9P6Xv5FiHza+gHlCntiWTMrU8bzqJHH4VYm6gq1RB+dQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.3.3.tgz",
+      "integrity": "sha512-sYL0t2guakJ+nDSQANH54uz5q1YxaNCn5C3lr+7BoRD49dX7Z6k7094yqOPEy8trzqdIoQVFpgewVA6IC/FeyQ==",
       "peer": true,
       "requires": {
-        "@module-federation/sdk": "2.3.1",
-        "find-pkg": "2.0.0",
-        "fs-extra": "9.1.0"
+        "@module-federation/sdk": "2.3.3",
+        "find-pkg": "2.0.0"
       }
     },
     "@module-federation/manifest": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.3.1.tgz",
-      "integrity": "sha512-BXckns3ux6Z9XiB2Bpirj/Q3FcQnxiyKt0rx0HmF0/7V6Zy2mwR/011eoeRGHN9N2HZcIxgQcWgMtxl5FAqxyg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.3.3.tgz",
+      "integrity": "sha512-mAEXuo5sGt8FUDzftU8f0ci0PbsZIDcLRYX9AkXwbXg0JRyVEvWyiBrEKF+zZuy7YM7eRdyp6JjLJPDzufhj5w==",
       "peer": true,
       "requires": {
-        "@module-federation/dts-plugin": "2.3.1",
-        "@module-federation/managers": "2.3.1",
-        "@module-federation/sdk": "2.3.1",
-        "chalk": "3.0.0",
+        "@module-federation/dts-plugin": "2.3.3",
+        "@module-federation/managers": "2.3.3",
+        "@module-federation/sdk": "2.3.3",
         "find-pkg": "2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "peer": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "peer": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "@module-federation/rspack": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.3.1.tgz",
-      "integrity": "sha512-pZmLSDkD7nDsCc377Q8sB1Yu2iMYFj72VS/Fb8B7uTmhYwU1wqDK9zPwaxauim5Y4TqQBdy/hPzNES3f4lG33Q==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.3.3.tgz",
+      "integrity": "sha512-4s3G+wXZ6J3rKe0EeZnGLQUM7y+qpiI5NM3U6ylZuxD8q7mAwQVHThbH6ruDYUNDVEOc6N0j/+/LdfGRw+e5xw==",
       "peer": true,
       "requires": {
-        "@module-federation/bridge-react-webpack-plugin": "2.3.1",
-        "@module-federation/dts-plugin": "2.3.1",
-        "@module-federation/inject-external-runtime-core-plugin": "2.3.1",
-        "@module-federation/managers": "2.3.1",
-        "@module-federation/manifest": "2.3.1",
-        "@module-federation/runtime-tools": "2.3.1",
-        "@module-federation/sdk": "2.3.1"
+        "@module-federation/bridge-react-webpack-plugin": "2.3.3",
+        "@module-federation/dts-plugin": "2.3.3",
+        "@module-federation/inject-external-runtime-core-plugin": "2.3.3",
+        "@module-federation/managers": "2.3.3",
+        "@module-federation/manifest": "2.3.3",
+        "@module-federation/runtime-tools": "2.3.3",
+        "@module-federation/sdk": "2.3.3"
       }
     },
     "@module-federation/runtime": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.3.1.tgz",
-      "integrity": "sha512-NiKelHKzOf1Vz8oqcxC/XRUAW224O6lKj9xD0cfp5Bp343iu6s58RlLvX1ypF+UpCl3jA4JM8npGax/3jjyifw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.3.3.tgz",
+      "integrity": "sha512-JYJ3qv9V85DtBtT/ppDuJNwBTUrYqqZDYcyiTzwY5+44dC5QPvgJ//F+BOhAhZ02WkZV0b4jsKTyLOC3vXKGqQ==",
       "peer": true,
       "requires": {
-        "@module-federation/error-codes": "2.3.1",
-        "@module-federation/runtime-core": "2.3.1",
-        "@module-federation/sdk": "2.3.1"
+        "@module-federation/error-codes": "2.3.3",
+        "@module-federation/runtime-core": "2.3.3",
+        "@module-federation/sdk": "2.3.3"
       }
     },
     "@module-federation/runtime-core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.3.1.tgz",
-      "integrity": "sha512-E0WgaCn32AWzD0n6SCH7VQ+kxk46XyX432PQWARgyQzCX/wyLkaT+We3A18RVNUevRT85YHLrrVIhMKJJVHgjA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.3.3.tgz",
+      "integrity": "sha512-B07LDH9KxhBO3GbULGW64mQFVQBtrEd3PoaCBm7XR1IbU8rMQUJQjDNVZgXYcyhRPBVP+3KWZuiaKFRiNb6PQw==",
       "peer": true,
       "requires": {
-        "@module-federation/error-codes": "2.3.1",
-        "@module-federation/sdk": "2.3.1"
+        "@module-federation/error-codes": "2.3.3",
+        "@module-federation/sdk": "2.3.3"
       }
     },
     "@module-federation/runtime-tools": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.3.1.tgz",
-      "integrity": "sha512-JrTKnNxIglnwrycPHUz9vARHLWqdecgFJxhmu8991z5CjktHc5JIelCbQS5Ur2lABjuwBdlyw8pH2xI3EJpbOg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.3.3.tgz",
+      "integrity": "sha512-XODzyLbBYcy4wnYBXKIBqaHPVfBx1HshGdjZmSctDDnx9/VYgdx9DShb6UI+WuQBKJgPzTcx4xbvbCM4SdMilQ==",
       "peer": true,
       "requires": {
-        "@module-federation/runtime": "2.3.1",
-        "@module-federation/webpack-bundler-runtime": "2.3.1"
+        "@module-federation/runtime": "2.3.3",
+        "@module-federation/webpack-bundler-runtime": "2.3.3"
       }
     },
     "@module-federation/sdk": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.1.tgz",
-      "integrity": "sha512-lgWxFZyLRKDXWRGlV6ROjFJ6MRaJTxs0bBnS6hS9ONfr/0TkeW4JzDbsfzrB8g4p6IgSKB+wQ9XfibJCGBI5OQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.3.tgz",
+      "integrity": "sha512-mwCS+LQdqiSc6fM5iz/S60ibaFNSH6kNqlZkCRIuS4yjdZ+jgnihz+6xp1QzppvfFgKLhEHBiXOmcYOdk3Ckew==",
       "peer": true,
       "requires": {}
     },
     "@module-federation/third-party-dts-extractor": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.3.1.tgz",
-      "integrity": "sha512-YpTLzM7H9damh31JX7eFBiCCR1mbibzS4i4JEa4fZ5ICT4hfNIuaAx1OeICGDOzSdl35TYegegCjk91oX6xCJQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.3.3.tgz",
+      "integrity": "sha512-rR94TjC1QVQLQPTazI0waLc76hI8dnv6aHTl+PUEIY9s5hXp8TA85XS0QJQqIf2KTjlPgZbWAwyFjOAJluTjaw==",
       "peer": true,
       "requires": {
         "find-pkg": "2.0.0",
-        "fs-extra": "9.1.0",
         "resolve": "1.22.8"
       },
       "dependencies": {
@@ -18012,14 +17773,14 @@
       }
     },
     "@module-federation/webpack-bundler-runtime": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.3.1.tgz",
-      "integrity": "sha512-fnsMncVdBYv7a1gN5ElNK1uA9dmGUgaNqcoNiv9xRtpxFYswchl1kbgxPTliCb8U7quihdWZos7P2lvpYeVRwg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.3.3.tgz",
+      "integrity": "sha512-W+P6ZF9J3gwnQuoF07YV0OiR1D6sI/uErUu4+c3QXxka3orANUHujkddNSsDxL1obAGoJa7Da99crZKf7u2j/w==",
       "peer": true,
       "requires": {
-        "@module-federation/error-codes": "2.3.1",
-        "@module-federation/runtime": "2.3.1",
-        "@module-federation/sdk": "2.3.1"
+        "@module-federation/error-codes": "2.3.3",
+        "@module-federation/runtime": "2.3.3",
+        "@module-federation/sdk": "2.3.3"
       }
     },
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -19799,9 +19560,9 @@
       }
     },
     "adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
       "peer": true
     },
     "agent-base": {
@@ -19922,18 +19683,6 @@
         "tslib": "^2.8.1"
       }
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "peer": true
-    },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "peer": true
-    },
     "autoprefixer": {
       "version": "10.4.27",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
@@ -19944,17 +19693,6 @@
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
-      "peer": true,
-      "requires": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "babel-loader": {
@@ -20306,15 +20044,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "peer": true,
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -20551,12 +20280,6 @@
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
       "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "peer": true
-    },
     "depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -20733,18 +20456,6 @@
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "requires": {
         "es-errors": "^1.3.0"
-      }
-    },
-    "es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "peer": true,
-      "requires": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       }
     },
     "esbuild": {
@@ -21093,19 +20804,6 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
     },
-    "form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "peer": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      }
-    },
     "formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -21129,18 +20827,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "dev": true
-    },
-    "fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "peer": true,
-      "requires": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      }
     },
     "fs-minipass": {
       "version": "3.0.3",
@@ -21298,15 +20984,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
-    },
-    "has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "peer": true,
-      "requires": {
-        "has-symbols": "^1.0.3"
-      }
     },
     "hasown": {
       "version": "2.0.2",
@@ -21784,16 +21461,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
-    },
-    "jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "peer": true,
-      "requires": {
-        "graceful-fs": "^4.1.6",
-        "universalify": "^2.0.0"
-      }
     },
     "jsonparse": {
       "version": "1.3.1",
@@ -23118,12 +22785,6 @@
         "ipaddr.js": "1.9.1"
       }
     },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "peer": true
-    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -24196,12 +23857,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
       "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ=="
-    },
-    "universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "peer": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/angular-overview/package-lock.json
+++ b/angular-overview/package-lock.json
@@ -10255,9 +10255,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "dev": true,
       "engines": {
         "node": ">=16.9.0"
@@ -22677,9 +22677,9 @@
       }
     },
     "hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "dev": true
     },
     "hosted-git-info": {

--- a/angular-overview/package-lock.json
+++ b/angular-overview/package-lock.json
@@ -9915,9 +9915,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -22466,9 +22466,9 @@
       "devOptional": true
     },
     "follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
     },
     "formdata-polyfill": {
       "version": "4.0.10",


### PR DESCRIPTION
## Batch Dependency Updates — 2026-04-26

This PR combines 6 Dependabot PRs below the auto-merge threshold (8.0):

- #115: chore(deps): bump axios and @module-federation/enhanced in /angular-menu
- #113: chore(deps): bump hono from 4.12.12 to 4.12.14 in /angular-libs
- #112: chore(deps): bump hono from 4.12.12 to 4.12.14 in /angular-overview
- #111: chore(deps): bump follow-redirects from 1.15.11 to 1.16.0 in /angular-menu
- #110: chore(deps): bump follow-redirects from 1.15.11 to 1.16.0 in /angular-overview
- #109: chore(deps): bump follow-redirects from 1.15.6 to 1.16.0 in /angular-libs

Reviewed and batched by openclaw pr-review CronJob.